### PR TITLE
Bug fixed

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -9,7 +9,7 @@ converter = opencc.OpenCC('s2t.json')
 FILE = sys.argv[1]
 
 HANZI_RE = re.compile('^[\u4e00-\u9fa5]+$')
-YAML_HEADER = "---\nname: luna_pinyin.zhwiki.dict.yaml\nversion: \"2020.05.23\"\nsort: by_weight\nuse_preset_vocabulary: true\n...\n"
+YAML_HEADER = "# encoding: utf-8\n\n---\nname: luna_pinyin.zhwiki\nversion: \"2020.05.29\"\nsort: by_weight\nuse_preset_vocabulary: true\nimport_tables:\n  - luna_pinyin\n...\n"
 print(YAML_HEADER)
 count = 0
 with open(FILE) as f:


### PR DESCRIPTION
Add encoding declaration.
Remove unnecessary .dict.yaml suffix because rime will autonomously add it.
Add single character table(单字码表).